### PR TITLE
Add page base navigation using L1 and R1 

### DIFF
--- a/src/storyTeller/app_selector.h
+++ b/src/storyTeller/app_selector.h
@@ -160,6 +160,37 @@ void app_down(void) {
         }
     }
 }
+void app_page_previous(void) {
+    if (appOpened) {
+        switch (appIndex) {
+            case APP_STORIES:
+            case APP_NIGHTMODE:
+                stories_page_previous();
+                break;
+            case APP_MUSIC:
+                musicplayer_page_previous();
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+void app_page_next(void) {
+    if (appOpened) {
+        switch (appIndex) {
+            case APP_STORIES:
+            case APP_NIGHTMODE:
+                stories_page_next();
+                break;
+            case APP_MUSIC:
+                musicplayer_page_next();
+                break;
+            default:
+                break;
+        }
+    }
+}
 
 void app_pause(void) {
     if (appOpened) {

--- a/src/storyTeller/music_player.h
+++ b/src/storyTeller/music_player.h
@@ -404,6 +404,37 @@ void musicplayer_previous(void) {
         musicplayer_changeAlbum(-1);
     }
 }
+void musicplayer_page_previous(void) {
+    if (musicPlayerMode != MUSICPLAYER_MODE_ALBUM)
+        return;
+    
+    int current_page = musicPlayerAlbumIndex / 9;
+    int total_pages = (musicPlayerAlbumsCount - 1) / 9;
+    
+    if (current_page > 0) {
+        musicPlayerAlbumIndex = (current_page - 1) * 9;
+    } else {
+        musicPlayerAlbumIndex = total_pages * 9;
+    }
+    
+    musicplayer_interfacealbum_draw();
+}
+
+void musicplayer_page_next(void) {
+    if (musicPlayerMode != MUSICPLAYER_MODE_ALBUM)
+        return;
+    
+    int current_page = musicPlayerAlbumIndex / 9;
+    int total_pages = (musicPlayerAlbumsCount - 1) / 9;
+    
+    if (current_page < total_pages) {
+        musicPlayerAlbumIndex = (current_page + 1) * 9;
+    } else {
+        musicPlayerAlbumIndex = 0;
+    }
+    
+    musicplayer_interfacealbum_draw();
+}
 
 void musicplayer_ok(void) {
     if (musicPlayerTracksCount == 0) {

--- a/src/storyTeller/stories_reader.h
+++ b/src/storyTeller/stories_reader.h
@@ -1102,6 +1102,37 @@ void stories_previous(void) {
         }
     }
 }
+void stories_page_previous(void) {
+    if (storiesDiplayMode != STORIES_DISPLAY_MODE_TILES || storyActionKey[0] != '\0')
+        return;
+    
+    int current_page = storyIndex / 9;
+    int total_pages = (storiesCount - 1) / 9;
+    
+    if (current_page > 0) {
+        storyIndex = (current_page - 1) * 9;
+    } else {
+        storyIndex = total_pages * 9;
+    }
+    
+    stories_title_tiles();
+}
+
+void stories_page_next(void) {
+    if (storiesDiplayMode != STORIES_DISPLAY_MODE_TILES || storyActionKey[0] != '\0')
+        return;
+    
+    int current_page = storyIndex / 9;
+    int total_pages = (storiesCount - 1) / 9;
+    
+    if (current_page < total_pages) {
+        storyIndex = (current_page + 1) * 9;
+    } else {
+        storyIndex = 0;
+    }
+    
+    stories_title_tiles();
+}
 
 void stories_forceRefreshScreen(void) {
     if (applock_isLockRecentlyChanged() || applock_isUnlocking() || app_volume_isShowed() || app_brightness_isShowed()) {

--- a/src/storyTeller/storyTeller.c
+++ b/src/storyTeller/storyTeller.c
@@ -140,6 +140,12 @@ int main(int argc, char *argv[]) {
                         case HW_BTN_X :
                             app_home();
                             break;
+                        case HW_BTN_L1 :
+                            app_page_previous();
+                            break;
+                        case HW_BTN_R1 :
+                            app_page_next();
+                            break;
                     }
 
                     if (isMenuPressed) {


### PR DESCRIPTION
- Page-based navigation using L1 (previous) and R1 (next) shoulder buttons  
- Circular wraparound: first page ↔ last page navigation  
- Context-aware activation (only in grid/album views)  
- Automatic page calculation based on collection size  
- Consistent behavior across Stories and Music modules  