### PR TITLE
fix(settings): disable settings.mute init

### DIFF
--- a/src/common/system/settings.h
+++ b/src/common/system/settings.h
@@ -170,7 +170,8 @@ void settings_load(void)
     settings.menu_button_haptics = !config_flag_get(".noMenuHaptics");
     settings.show_recents = config_flag_get(".showRecents");
     settings.show_expert = config_flag_get(".showExpert");
-    settings.mute = config_flag_get(".muteVolume");
+    // .muteVolume file could be written by official Onion, making it impossible to unmute in Telmi
+    // settings.mute = config_flag_get(".muteVolume");
     settings.disable_standby = config_flag_get(".disableStandby");
     settings.enable_logging = config_flag_get(".logging");
 


### PR DESCRIPTION
If user is running Onion OS (official) and swaps the SD for Telmi while running,
 Onion may write .muteVolume file to Telmi SD.
If that happens, Telmi will be stuck muted with no way (in Telmi) to unmute.

Built & tested (no longer muted when `.muteVolume` file is present).