### PR TITLE
feat: thread song duration

### DIFF
--- a/src/storyTeller/music_player.h
+++ b/src/storyTeller/music_player.h
@@ -135,12 +135,18 @@ void musicplayer_interfaceplayer_drawInterface(bool forceDraw) {
 
     sprintf(writeTitle, "%s. %s", track, title);
     sprintf(writeArtist, "%s - %s", artist, album);
-    sprintf(writeDuration, "%i:%02i", musicDuration / 60, musicDuration % 60);
+    if (musicDuration > 0) {
+        sprintf(writeDuration, "%i:%02i", musicDuration / 60, musicDuration % 60);
+    } else {
+        sprintf(writeDuration, "-:--");
+    }
     sprintf(writeTime, "%i:%02i", musicPosition / 60, musicPosition % 60);
     sprintf(fileImageName, "%s.png", imageName);
 
     video_screenBlack();
-    video_drawRectangle(185, 258, (int) ((double) musicPosition * 422.0 / (double) musicDuration), 12, 255, 186, 0);
+    if (musicDuration > 0) {
+        video_drawRectangle(185, 258, (int) ((double) musicPosition * 422.0 / (double) musicDuration), 12, 255, 186, 0);
+    }
     video_screenAddImage(SYSTEM_RESOURCES, "musicPlayer.png", 0, 0, 640);
     video_screenAddImage(MUSICPLAYER_RESOURCES, fileImageName, 24, 176, 128);
     video_screenWriteFont(writeTitle, fontBold24, colorWhite, 185, 190, SDL_ALIGN_LEFT);
@@ -244,7 +250,7 @@ void musicplayer_screenUpdate(bool forceDraw) {
 }
 
 bool musicplayer_callCallback(void) {
-    if (callback_musicplayer_autoplay != NULL && audio_getPosition() == audio_getDuration()) {
+    if (callback_musicplayer_autoplay != NULL && audio_isFinished()) {
         callback_musicplayer_autoplay();
         return true;
     }
@@ -373,7 +379,7 @@ void musicplayer_rewind(int time) {
     musicPlayerTrackPosition = audio_getPosition() + (double) time;
     if (musicPlayerTrackPosition < 0) {
         musicPlayerTrackPosition = 0.0;
-    } else if (musicPlayerTrackPosition >= musicDuration) {
+    } else if (musicDuration > 0 && musicPlayerTrackPosition >= musicDuration) {
         callback_musicplayer_autoplay();
         return;
     }

--- a/src/storyTeller/music_player.h
+++ b/src/storyTeller/music_player.h
@@ -43,6 +43,7 @@ static int musicPlayerRepeatMode = MUSICPLAYER_REPEAT_ALL;
 static int musicPlayerDrawInterfaceTime = 0;
 static long int musicPlayerScreenUpdateTime = 0;
 static long int musicPlayerLastActivity = 0;
+static long int musicPlayerMusicLoadTime = 0;
 
 static void (*callback_musicplayer_autoplay)(void);
 
@@ -137,8 +138,12 @@ void musicplayer_interfaceplayer_drawInterface(bool forceDraw) {
     sprintf(writeArtist, "%s - %s", artist, album);
     if (musicDuration > 0) {
         sprintf(writeDuration, "%i:%02i", musicDuration / 60, musicDuration % 60);
-    } else {
+    } else if (get_time() - musicPlayerMusicLoadTime > 1) {
+        // Only show "-:--" after 1 second of waiting (avoids flicker for short songs)
         sprintf(writeDuration, "-:--");
+    } else {
+        // Within first second, show empty to avoid flicker
+        writeDuration[0] = '\0';
     }
     sprintf(writeTime, "%i:%02i", musicPosition / 60, musicPosition % 60);
     sprintf(fileImageName, "%s.png", imageName);
@@ -293,6 +298,7 @@ void musicplayer_load(void) {
     bool isPaused = Mix_PlayingMusic() == 1 && Mix_PausedMusic() == 1;
 
     audio_play(MUSICPLAYER_RESOURCES, musicPlayerTracksList[musicPlayerTrackIndex], musicPlayerTrackPosition);
+    musicPlayerMusicLoadTime = get_time();
 
     if (isPaused) {
         Mix_PauseMusic();

--- a/src/storyTeller/sdl_helper.h
+++ b/src/storyTeller/sdl_helper.h
@@ -2,6 +2,7 @@
 #define STORYTELLER_SDL_HELPER__
 
 #include <math.h>
+#include <pthread.h>
 
 #include "SDL2/SDL.h"
 #include "SDL2/SDL_mixer.h"
@@ -33,6 +34,9 @@ static SDL_Texture *texture = NULL;
 static SDL_Renderer *renderer = NULL;
 static Mix_Music *music;
 static double musicDuration;
+static pthread_t durationThread;
+static bool durationThreadRunning = false;
+static char durationThreadPath[STR_MAX * 2];
 static TTF_Font *fontBold24;
 static TTF_Font *fontBold20;
 static TTF_Font *fontBold18;
@@ -239,6 +243,19 @@ void video_displayBlackScreen(void) {
     video_applyToVideo();
 }
 
+void *audio_calculate_duration_thread(void *arg) {
+    Mix_Music *tempMusic = Mix_LoadMUS(durationThreadPath);
+    if (tempMusic != NULL) {
+        double duration = Mix_MusicDuration(tempMusic);
+        Mix_FreeMusic(tempMusic);
+        if (music != NULL) {
+            musicDuration = duration;
+        }
+    }
+    durationThreadRunning = false;
+    return NULL;
+}
+
 void audio_free_music(void) {
     if (music != NULL) {
         Mix_HaltMusic();
@@ -264,13 +281,26 @@ double audio_getPosition(void) {
     return 0.0;
 }
 
+bool audio_isFinished(void) {
+    return music != NULL && Mix_PlayingMusic() == 0;
+}
+
 void audio_play_path(char *soundPath, double position) {
+    if (durationThreadRunning) {
+        pthread_join(durationThread, NULL);
+        durationThreadRunning = false;
+    }
+
     audio_free_music();
     music = Mix_LoadMUS(soundPath);
     if (music != NULL) {
-        musicDuration = Mix_MusicDuration(music);
+        musicDuration = -1.0;
         Mix_PlayMusic(music, 1);
         Mix_SetMusicPosition(position);
+
+        strcpy(durationThreadPath, soundPath);
+        durationThreadRunning = true;
+        pthread_create(&durationThread, NULL, audio_calculate_duration_thread, NULL);
     } else {
         musicDuration = 0.0;
     }
@@ -310,6 +340,11 @@ void video_audio_init(void) {
 
 
 void video_audio_quit(void) {
+    if (durationThreadRunning) {
+        pthread_join(durationThread, NULL);
+        durationThreadRunning = false;
+    }
+
     TTF_Quit();
 
     if (music != NULL) {

--- a/src/storyTeller/sdl_helper.h
+++ b/src/storyTeller/sdl_helper.h
@@ -37,6 +37,7 @@ static double musicDuration;
 static pthread_t durationThread;
 static bool durationThreadRunning = false;
 static char durationThreadPath[STR_MAX * 2];
+static char currentMusicPath[STR_MAX * 2];
 static TTF_Font *fontBold24;
 static TTF_Font *fontBold20;
 static TTF_Font *fontBold18;
@@ -244,11 +245,14 @@ void video_displayBlackScreen(void) {
 }
 
 void *audio_calculate_duration_thread(void *arg) {
-    Mix_Music *tempMusic = Mix_LoadMUS(durationThreadPath);
+    char pathToCalculate[STR_MAX * 2];
+    strcpy(pathToCalculate, durationThreadPath);
+
+    Mix_Music *tempMusic = Mix_LoadMUS(pathToCalculate);
     if (tempMusic != NULL) {
         double duration = Mix_MusicDuration(tempMusic);
         Mix_FreeMusic(tempMusic);
-        if (music != NULL) {
+        if (strcmp(pathToCalculate, currentMusicPath) == 0) {
             musicDuration = duration;
         }
     }
@@ -261,6 +265,7 @@ void audio_free_music(void) {
         Mix_HaltMusic();
         Mix_FreeMusic(music);
         music = NULL;
+        currentMusicPath[0] = '\0';
     }
 }
 
@@ -286,23 +291,25 @@ bool audio_isFinished(void) {
 }
 
 void audio_play_path(char *soundPath, double position) {
-    if (durationThreadRunning) {
-        pthread_join(durationThread, NULL);
-        durationThreadRunning = false;
-    }
-
     audio_free_music();
     music = Mix_LoadMUS(soundPath);
     if (music != NULL) {
-        musicDuration = -1.0;
+        musicDuration = -1.0;  // Unknown until thread completes
+        strcpy(currentMusicPath, soundPath);
         Mix_PlayMusic(music, 1);
         Mix_SetMusicPosition(position);
+
+        if (durationThreadRunning) {
+            pthread_join(durationThread, NULL);
+            durationThreadRunning = false;
+        }
 
         strcpy(durationThreadPath, soundPath);
         durationThreadRunning = true;
         pthread_create(&durationThread, NULL, audio_calculate_duration_thread, NULL);
     } else {
         musicDuration = 0.0;
+        currentMusicPath[0] = '\0';
     }
 }
 
@@ -340,6 +347,8 @@ void video_audio_init(void) {
 
 
 void video_audio_quit(void) {
+    currentMusicPath[0] = '\0';
+
     if (durationThreadRunning) {
         pthread_join(durationThread, NULL);
         durationThreadRunning = false;

--- a/src/storyTeller/sdl_helper.h
+++ b/src/storyTeller/sdl_helper.h
@@ -306,7 +306,9 @@ void audio_play_path(char *soundPath, double position) {
 
         strcpy(durationThreadPath, soundPath);
         durationThreadRunning = true;
-        pthread_create(&durationThread, NULL, audio_calculate_duration_thread, NULL);
+        if (pthread_create(&durationThread, NULL, audio_calculate_duration_thread, NULL) != 0) {
+            durationThreadRunning = false; 
+        }
     } else {
         musicDuration = 0.0;
         currentMusicPath[0] = '\0';


### PR DESCRIPTION
# Before

Computing the duration would take about 30 seconds for a long song (i.e. a one hour song) as this computation was run in the main thread.

# After

Computing the duration is done in a new thread, making the UI non-blocking when switching between long songs.

# Notes

I don't know much about C so this PR was mostly vibe coded but I've tested on my own device and it works fine. Switching to a long song would take about 30 seconds, now it takes only a few seconds.

The result is actually surprising as the song loads faster and the duration is displayed properly even though my fix is about displaying `--:--` until the duration is properly computed, but hey it works 🤷. Short songs aren't impacted whatsoever, the duration is displayed instantly and they are loaded right away.